### PR TITLE
Re-run update status notification after the update

### DIFF
--- a/update/qubes-vm.sls
+++ b/update/qubes-vm.sls
@@ -48,3 +48,6 @@ update:
       - cmd: dsa-4371-update
 {% endif %}
 
+notify-updates:
+  cmd.run:
+    - name: /usr/lib/qubes/upgrades-status-notify


### PR DESCRIPTION
It may happen that no updates are available anymore (for example already installed). In this case apt nor dnf run our notification hooks, so informations about "no updates" is never send and template stays in "updates available" state forever.
    
Fixes QubesOS/qubes-issues#4650
