### PR TITLE
Disable deltarpm via Salt

### DIFF
--- a/update/qubes-vm.sls
+++ b/update/qubes-vm.sls
@@ -12,6 +12,11 @@ dnf-makecache:
     - source: salt://update/dnf-makecache
     - runas: root
     - stateful: True
+
+Disable deltarpm:
+  file.append:
+    - name: /etc/dnf/dnf.conf
+    - text: deltarpm=False
 {% endif %}
 
 update:
@@ -23,6 +28,7 @@ update:
     - require:
       - cmd: dnf-makecache
       - file: /usr/lib/rpm/macros.d/macros.qubes
+      - file: 'Disable deltarpm'
 {% endif %}
 
 notify-updates:


### PR DESCRIPTION
This disables deltarpm via Salt in Red Hat-based distros.