### PR TITLE
Avoid ugly state name

### DIFF
--- a/rpm_spec/qubes-mgmt-salt-dom0-update-dom0.spec.in
+++ b/rpm_spec/qubes-mgmt-salt-dom0-update-dom0.spec.in
@@ -44,6 +44,7 @@ qubesctl saltutil.sync_all refresh=true -l quiet --out quiet > /dev/null || true
 /srv/formulas/base/update-formula/update/qubes-vm.sls
 /srv/formulas/base/update-formula/update/qubes-dom0.sls
 /srv/formulas/base/update-formula/update/dnf-makecache
+/srv/formulas/base/update-formula/update/dnf-cleancache
 
 %attr(750, root, root) %dir /srv/formulas/test/update-formula
 /srv/formulas/test/update-formula/LICENSE

--- a/update/dnf-cleancache
+++ b/update/dnf-cleancache
@@ -1,0 +1,6 @@
+#!/bin/sh --
+if qubes-dom0-update --quiet --assumeyes --clean --action=clean expire-cache >/dev/null 2>&1; then
+    echo "result=True comment='Cache cleaned'"
+else
+    echo "result=False comment='Could not clean cache'"
+fi

--- a/update/qubes-dom0.sls
+++ b/update/qubes-dom0.sls
@@ -13,13 +13,9 @@
     - bufsize: file
 
 update:
-  cmd.run:
-    - name: |
-        if qubes-dom0-update --quiet --assumeyes --clean --action=clean expire-cache >/dev/null 2>&1; then
-            echo "result=True comment='Cache cleaned'"
-        else
-            echo "result=False comment='Could not clean cache'"
-        fi
+  cmd.script:
+    - source: salt://update/dnf-cleancache
+    - runas: root
     - stateful: True
   pkg.uptodate:
     - refresh: False


### PR DESCRIPTION
cmd.run is for short commands, not long scripts.  Use cmd.script
instead, which avoids printing the body of the script.

Fixes QubesOS/qubes-issues#7641.