### PR TITLE
Abort latest_version() if downloading pkg list fails

### DIFF
--- a/_modules/qubes_dom0_update.py
+++ b/_modules/qubes_dom0_update.py
@@ -538,15 +538,12 @@ def latest_version(*names, **kwargs):
     out = _call_yum(cmd, qubes_dom0_update=True, ignore_retcode=True)
 
     if out['retcode'] != 0:
-        # Check first if this is just a matter of the packages being
-        # up-to-date.
-        if not all([x in cur_pkgs for x in names]):
-            raise CommandExecutionError(
-                'Problem encountered getting latest version for the '
-                'following package(s): %s. Stderr follows: \n%s',
-                ', '.join(names),
-                out['stderr']
-            )
+        raise CommandExecutionError(
+            'Problem encountered getting latest version for the '
+            'following package(s): %s. Stderr follows: \n%s',
+            ', '.join(names),
+            out['stderr']
+        )
     else:
         # Sort by version number (highest to lowest) for loop below
         updates = sorted(


### PR DESCRIPTION
Previously it aborted only if some package was missing, but failed to
set 'updates' variable. That was partial change in
QubesOS/qubes-issues#6585 (before which, it aborted only on non-empty
stderr). Finish the change to abort on any metadata download failure. It
may result in failures that in some cases would be harmless, but
aborting on any metadata download failure makes it less likely to
falsely report no updates if there are some.

Fixes QubesOS/qubes-issues#7962
Related to QubesOS/qubes-issues#6585