### PR TITLE
Unite setopt argument with equal sign

### DIFF
--- a/_modules/qubes_dom0_update.py
+++ b/_modules/qubes_dom0_update.py
@@ -339,7 +339,7 @@ def _get_options(**kwargs):
         ret.append(f"--branch={branch}")
 
     for item in setopt:
-        ret.extend(["--setopt", str(item)])
+        ret.extend(["--setopt=" + str(item)])
 
     if get_extra_options:
         # sorting here to make order uniform, makes unit testing more reliable


### PR DESCRIPTION
Avoid qubes-dom0-update treating the setopt value as a command to dnf.

Fix: https://github.com/QubesOS/qubes-issues/issues/9509